### PR TITLE
style(style): prevent overlap of clickable headers on preceding links

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -79,3 +79,12 @@ h2 ~ h3
     margin-top: -4rem !important
 h2 + h3
     margin-top: -4rem !important;
+
+.content__default > *:not(h1):not(h2):not(h3):not(h4)
+    @apply relative z-20
+
+h1, h2, h3, h4 
+    @apply z-10
+
+.navbar
+    @apply z-50


### PR DESCRIPTION
There might be better ways to do this, but noticed that content above the headers were not clickable. Played with z-index to fix. 

![image](https://user-images.githubusercontent.com/15135669/70108982-a1ee5a00-1618-11ea-846c-98ec576830c1.png)
